### PR TITLE
Feat: Implemented Aspiration Window

### DIFF
--- a/include/engine/Engine.hpp
+++ b/include/engine/Engine.hpp
@@ -80,7 +80,10 @@ class Engine {
     // NMP
     static inline constexpr int _NMP_REDUCTION = 2;
 
-    static inline constexpr int _SEARCH_DEPTH = 9;
+    static inline constexpr int _SEARCH_DEPTH = 8;
+
+    // Aspiration Window
+    static inline constexpr int _ASPIRATION_WINDOW_VALUE = 50;
 
     uint64_t _bitboards[2][6];
     uint64_t _occupancies[2];


### PR DESCRIPTION
## Description
- Implemented aspiration window
- Uses a proof that if the score is $$\alpha<score<\beta$$, then we may narrow the search down, known as the aspiration window
- Otherwise, we may fail low or fail high, in this case, we must perform a re-search or else we might've missed some best moves with the narrow window